### PR TITLE
fix: corrigir filtro de coleção na listagem de termos

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -2675,6 +2675,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",

--- a/backend/src/contexts/admin/views/terms-list.ejs
+++ b/backend/src/contexts/admin/views/terms-list.ejs
@@ -19,8 +19,22 @@
   totalPages: 1,
   searchQuery: '',
   statusFilter: '',
+  collectionFilter: new URLSearchParams(window.location.search).get('collection') || '',
+  collectionName: '',
   async init() {
+    if (this.collectionFilter) {
+      await this.loadCollectionName();
+    }
     await this.loadTerms();
+  },
+  async loadCollectionName() {
+    try {
+      const response = await fetch(`/api/v1/collections/${this.collectionFilter}`);
+      const collection = await response.json();
+      this.collectionName = collection.name;
+    } catch (error) {
+      console.error('Error loading collection name:', error);
+    }
   },
   async loadTerms() {
     this.loading = true;
@@ -29,7 +43,8 @@
         page: this.page,
         limit: 20,
         ...(this.searchQuery && { q: this.searchQuery }),
-        ...(this.statusFilter && { status: this.statusFilter })
+        ...(this.statusFilter && { status: this.statusFilter }),
+        ...(this.collectionFilter && { collections: this.collectionFilter })
       });
 
       const response = await fetch(`/api/v1/admin/terms?${params}`);
@@ -41,6 +56,9 @@
     } finally {
       this.loading = false;
     }
+  },
+  clearCollectionFilter() {
+    window.location.href = '/terms';
   },
   async deleteTerm(id) {
     if (!confirm('Tem certeza que deseja excluir este termo?')) return;
@@ -99,6 +117,15 @@
     <div>
       <h1 class="text-3xl font-bold text-forest-700">Gerenciar Termos</h1>
       <p class="text-gray-600 mt-1">Administração do vocabulário controlado</p>
+      <!-- Collection Filter Badge -->
+      <div x-show="collectionFilter" class="mt-2">
+        <span class="inline-flex items-center gap-2 px-3 py-1 bg-forest-100 text-forest-700 rounded-full text-sm font-medium">
+          <span>Filtrando por coleção: <strong x-text="collectionName"></strong></span>
+          <button @click="clearCollectionFilter()" class="hover:text-forest-900" title="Remover filtro">
+            ✕
+          </button>
+        </span>
+      </div>
     </div>
     <a
       href="/terms/new"


### PR DESCRIPTION
O botão "Ver Termos" nos cards de coleção agora filtra corretamente os termos pela coleção selecionada. Também foi adicionado um badge visual indicando qual coleção está sendo filtrada, com opção de remover o filtro.

Mudanças:
- Adiciona leitura do parâmetro 'collection' da URL
- Passa parâmetro 'collections' para API de termos
- Exibe badge com nome da coleção e botão para limpar filtro
- Carrega nome da coleção via API para exibição

🤖 Generated with [Claude Code](https://claude.com/claude-code)